### PR TITLE
Update base.tplx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
     - cm-super # more fonts
     - texlive-xetex # latex to pdf converter
     - inkscape # for svgs in pdf output
+    - lmodern # latex package
 install:
     - wget https://github.com/jgm/pandoc/releases/download/2.7/pandoc-2.7-1-amd64.deb && sudo dpkg -i pandoc-2.7-1-amd64.deb
     - pip install --upgrade setuptools pip pytest

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -13,7 +13,7 @@ This template does not define a docclass, the inheriting class must define this.
     ((* block docclass *))((* endblock docclass *))
     
     ((* block packages *))
-    \usepackage[T1]{fontenc}
+    \usepackage{fontspec}
     % Nicer default font (+ math font) than Computer Modern for most use cases
     \usepackage{mathpazo}
 

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -46,7 +46,6 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{upquote} % Upright quotes for verbatim code
     \usepackage{eurosym} % defines \euro
     \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
-    \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range 


### PR DESCRIPTION
\usepackage[T1]{fontenc} shouldn't be used with xelatex and throws errors like "!Text line contains an invalid character".
\usepackage{fontspec} fixes this error.